### PR TITLE
Hard-coded user and group id for shopware's docker images

### DIFF
--- a/.psh.yaml.dist
+++ b/.psh.yaml.dist
@@ -33,13 +33,13 @@ const:
   PHP_VERSION: "7.1"
   APP_DEBUG: "1"
   APP_ENV: "dev"
+  USER_ID: "2020"
+  GROUP_ID: "2020"
+  USERKEY: "2020:2020"
 
 dynamic:
-  USERKEY: echo "$(id -u):$(id -g)"
   APP_ID: docker-compose ps -q app_server
   MYSQL_ID: docker-compose ps -q app_mysql
-  USER_ID: id -u
-  GROUP_ID: id -g
 
 environments:
   docker:

--- a/dev-ops/docker/containers/scriptcreator.sh
+++ b/dev-ops/docker/containers/scriptcreator.sh
@@ -2,8 +2,8 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-USERID=$(id -u)
-GROUP=$(id -g)
+USERID="2020"
+GROUP="2020"
 
 
 cat > $DIR/php7/createuser.sh <<DELIM


### PR DESCRIPTION
The Docker Team says themselves:
> Eliminate the “it works on my machine” problem once and for all.

That's not true for the shopware docker containers unfortunately.

### 1. Why is this change necessary?
My local user is in a group with ID 20. Shopware uses this ID for the group inside the docker container, too. The problem:

> Many Linux systems reserve the GID number range 0 to 99 for statically allocated groups[...]

from https://en.wikipedia.org/wiki/Group_identifier#Reserved_ranges

This means:
![docker](https://user-images.githubusercontent.com/1859343/31467344-ef21fcd0-aed9-11e7-9e5d-e0e0ea33e23d.png)

Now I can't build the container. We should rely on static variables inside our container so we are independent of the host system.

### 2. What does this change do, exactly?
The userID and groupID of the container's user won't be determinated by the host user's ids.

### 3. Describe each step to reproduce the issue or behaviour.
Use a unix system with a user's group's id is 20. Try to install the docker image. It fails.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.