### PR TITLE
Hard-coded user and group id for shopware's docker images

### DIFF
--- a/dev-ops/read-generator/Controller/templates/write_actions.txt
+++ b/dev-ops/read-generator/Controller/templates/write_actions.txt
@@ -96,7 +96,7 @@
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $#plural# = $this->#classLc#Repository->readDetail(
+        $#plural# = $this->#classLc#Repository->#detailRead#(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/dev-ops/read-generator/Extension/Generator.php
+++ b/dev-ops/read-generator/Extension/Generator.php
@@ -29,15 +29,31 @@ class Generator
     {
         $class = Util::snakeCaseToCamelCase($table);
 
+        $writeMethod = '';
+        $writeSubscribe = '';
+
+        if (preg_match('#_ro$#i', $table)) {
+            $writeMethod = file_get_contents(__DIR__ . '/templates/extension_write_method.txt');
+            $writeSubscribe = file_get_contents(__DIR__ . '/templates/extension_write_subscribe.txt');
+        }
+
         $template = __DIR__ . '/templates/extension.txt';
         if (Util::getAssociationsForDetailStruct($table, $config)) {
             $template = __DIR__ . '/templates/extension_detail.txt';
         }
 
+        $template = file_get_contents($template);
+
+        $template = str_replace(
+            ['#writeMethod#', '#writeSubscribe#'],
+            [$writeMethod, $writeSubscribe],
+            $template
+        );
+
         $template = str_replace(
             ['#classUc#', '#classLc#'],
             [ucfirst($class), lcfirst($class)],
-            file_get_contents($template)
+            $template
         );
 
         $file = $this->directory.'/'.ucfirst($class).'/Extension/'.ucfirst($class).'Extension.php';

--- a/dev-ops/read-generator/Extension/templates/extension.txt
+++ b/dev-ops/read-generator/Extension/templates/extension.txt
@@ -17,7 +17,7 @@ abstract class #classUc#Extension implements ExtensionInterface, EventSubscriber
     {
         return [
             #classUc#BasicLoadedEvent::NAME => '#classLc#BasicLoaded',
-            #classUc#WrittenEvent::NAME => '#classLc#Written',
+            #writeSubscribe#
         ];
     }
 
@@ -50,6 +50,5 @@ abstract class #classUc#Extension implements ExtensionInterface, EventSubscriber
     public function #classLc#BasicLoaded(#classUc#BasicLoadedEvent $event): void
     { }
 
-    public function #classLc#Written(#classUc#WrittenEvent $event): void
-    { }
+    #writeMethod#
 }

--- a/dev-ops/read-generator/Extension/templates/extension_detail.txt
+++ b/dev-ops/read-generator/Extension/templates/extension_detail.txt
@@ -19,7 +19,7 @@ abstract class #classUc#Extension implements ExtensionInterface, EventSubscriber
         return [
             #classUc#BasicLoadedEvent::NAME => '#classLc#BasicLoaded',
             #classUc#DetailLoadedEvent::NAME => '#classLc#DetailLoaded',
-            #classUc#WrittenEvent::NAME => '#classLc#Written',
+            #writeSubscribe#
         ];
     }
 
@@ -55,7 +55,6 @@ abstract class #classUc#Extension implements ExtensionInterface, EventSubscriber
     public function #classLc#DetailLoaded(#classUc#DetailLoadedEvent $event): void
     { }
 
-    public function #classLc#Written(#classUc#WrittenEvent $event): void
-    { }
+    #writeMethod#
 
 }

--- a/dev-ops/read-generator/Extension/templates/extension_write_method.txt
+++ b/dev-ops/read-generator/Extension/templates/extension_write_method.txt
@@ -1,0 +1,2 @@
+public function #classLc#Written(#classUc#WrittenEvent $event): void
+{ }

--- a/dev-ops/read-generator/Extension/templates/extension_write_subscribe.txt
+++ b/dev-ops/read-generator/Extension/templates/extension_write_subscribe.txt
@@ -1,0 +1,1 @@
+#classUc#WrittenEvent::NAME => '#classLc#Written',

--- a/src/Album/Extension/AlbumExtension.php
+++ b/src/Album/Extension/AlbumExtension.php
@@ -2,15 +2,15 @@
 
 namespace Shopware\Album\Extension;
 
+use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Album\Event\AlbumBasicLoadedEvent;
 use Shopware\Album\Event\AlbumDetailLoadedEvent;
 use Shopware\Album\Event\AlbumWrittenEvent;
-use Shopware\Album\Struct\AlbumBasicStruct;
-use Shopware\Context\Struct\TranslationContext;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Album\Struct\AlbumBasicStruct;
 
 abstract class AlbumExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class AlbumExtension implements ExtensionInterface, EventSubscriberInte
         return [
             AlbumBasicLoadedEvent::NAME => 'albumBasicLoaded',
             AlbumDetailLoadedEvent::NAME => 'albumDetailLoaded',
-            AlbumWrittenEvent::NAME => 'albumWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class AlbumExtension implements ExtensionInterface, EventSubscriberInte
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class AlbumExtension implements ExtensionInterface, EventSubscriberInte
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function albumBasicLoaded(AlbumBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function albumDetailLoaded(AlbumDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function albumWritten(AlbumWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/Area/Extension/AreaExtension.php
+++ b/src/Area/Extension/AreaExtension.php
@@ -2,15 +2,15 @@
 
 namespace Shopware\Area\Extension;
 
+use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Area\Event\AreaBasicLoadedEvent;
 use Shopware\Area\Event\AreaDetailLoadedEvent;
 use Shopware\Area\Event\AreaWrittenEvent;
-use Shopware\Area\Struct\AreaBasicStruct;
-use Shopware\Context\Struct\TranslationContext;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Area\Struct\AreaBasicStruct;
 
 abstract class AreaExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class AreaExtension implements ExtensionInterface, EventSubscriberInter
         return [
             AreaBasicLoadedEvent::NAME => 'areaBasicLoaded',
             AreaDetailLoadedEvent::NAME => 'areaDetailLoaded',
-            AreaWrittenEvent::NAME => 'areaWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class AreaExtension implements ExtensionInterface, EventSubscriberInter
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class AreaExtension implements ExtensionInterface, EventSubscriberInter
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function areaBasicLoaded(AreaBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function areaDetailLoaded(AreaDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function areaWritten(AreaWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/AreaCountry/Extension/AreaCountryExtension.php
+++ b/src/AreaCountry/Extension/AreaCountryExtension.php
@@ -2,15 +2,15 @@
 
 namespace Shopware\AreaCountry\Extension;
 
+use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\AreaCountry\Event\AreaCountryBasicLoadedEvent;
 use Shopware\AreaCountry\Event\AreaCountryDetailLoadedEvent;
 use Shopware\AreaCountry\Event\AreaCountryWrittenEvent;
-use Shopware\AreaCountry\Struct\AreaCountryBasicStruct;
-use Shopware\Context\Struct\TranslationContext;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\AreaCountry\Struct\AreaCountryBasicStruct;
 
 abstract class AreaCountryExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class AreaCountryExtension implements ExtensionInterface, EventSubscrib
         return [
             AreaCountryBasicLoadedEvent::NAME => 'areaCountryBasicLoaded',
             AreaCountryDetailLoadedEvent::NAME => 'areaCountryDetailLoaded',
-            AreaCountryWrittenEvent::NAME => 'areaCountryWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class AreaCountryExtension implements ExtensionInterface, EventSubscrib
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class AreaCountryExtension implements ExtensionInterface, EventSubscrib
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function areaCountryBasicLoaded(AreaCountryBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function areaCountryDetailLoaded(AreaCountryDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function areaCountryWritten(AreaCountryWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/AreaCountryState/Controller/AreaCountryStateController.php
+++ b/src/AreaCountryState/Controller/AreaCountryStateController.php
@@ -190,7 +190,7 @@ class AreaCountryStateController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $areaCountryStates = $this->areaCountryStateRepository->readDetail(
+        $areaCountryStates = $this->areaCountryStateRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/AreaCountryState/Extension/AreaCountryStateExtension.php
+++ b/src/AreaCountryState/Extension/AreaCountryStateExtension.php
@@ -2,14 +2,14 @@
 
 namespace Shopware\AreaCountryState\Extension;
 
-use Shopware\AreaCountryState\Event\AreaCountryStateBasicLoadedEvent;
-use Shopware\AreaCountryState\Event\AreaCountryStateWrittenEvent;
-use Shopware\AreaCountryState\Struct\AreaCountryStateBasicStruct;
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
+use Shopware\AreaCountryState\Event\AreaCountryStateBasicLoadedEvent;
+use Shopware\AreaCountryState\Event\AreaCountryStateWrittenEvent;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\AreaCountryState\Struct\AreaCountryStateBasicStruct;
 
 abstract class AreaCountryStateExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class AreaCountryStateExtension implements ExtensionInterface, EventSub
     {
         return [
             AreaCountryStateBasicLoadedEvent::NAME => 'areaCountryStateBasicLoaded',
-            AreaCountryStateWrittenEvent::NAME => 'areaCountryStateWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class AreaCountryStateExtension implements ExtensionInterface, EventSub
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class AreaCountryStateExtension implements ExtensionInterface, EventSub
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function areaCountryStateBasicLoaded(AreaCountryStateBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function areaCountryStateWritten(AreaCountryStateWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Cart/LineItem/LineItem.php
+++ b/src/Cart/LineItem/LineItem.php
@@ -36,7 +36,7 @@ class LineItem extends Struct implements LineItemInterface
     protected $identifier;
 
     /**
-     * @var float
+     * @var int
      */
     protected $quantity;
 

--- a/src/Cart/Price/PriceRounding.php
+++ b/src/Cart/Price/PriceRounding.php
@@ -39,6 +39,6 @@ class PriceRounding
 
     public function round(float $price): float
     {
-        return round((float) $price, $this->precisions);
+        return round($price, $this->precisions);
     }
 }

--- a/src/Cart/Rule/RuleCollection.php
+++ b/src/Cart/Rule/RuleCollection.php
@@ -40,7 +40,7 @@ class RuleCollection extends Collection
     protected $flat = [];
 
     /**
-     * @var string[]
+     * @var bool[]
      */
     protected $classes = [];
 
@@ -84,7 +84,7 @@ class RuleCollection extends Collection
 
     private function addMeta(Rule $rule): void
     {
-        $this->classes[get_class($rule)] = 1;
+        $this->classes[get_class($rule)] = true;
 
         $this->flat[] = $rule;
 

--- a/src/Cart/Test/Common/ConfiguredLineItem.php
+++ b/src/Cart/Test/Common/ConfiguredLineItem.php
@@ -65,14 +65,14 @@ class ConfiguredLineItem extends \Shopware\Framework\Struct\Struct implements De
 
     /**
      * @param string              $identifier
-     * @param float               $quantity
+     * @param int                 $quantity
      * @param Price               $price
      * @param LineItemInterface   $lineItem
      * @param DeliveryInformation $deliveryInformation
      */
     public function __construct(
         $identifier,
-        $quantity = null,
+        ?int $quantity = null,
         Price $price = null,
         LineItemInterface $lineItem = null,
         DeliveryInformation $deliveryInformation = null

--- a/src/Cart/Test/Common/Generator.php
+++ b/src/Cart/Test/Common/Generator.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Area\Struct\AreaBasicStruct;
 use Shopware\AreaCountry\Struct\AreaCountryBasicStruct;
 use Shopware\AreaCountryState\Struct\AreaCountryStateBasicStruct;
-use Shopware\Cart\Delivery\DeliveryCalculator;
 use Shopware\Cart\Delivery\ShippingLocation;
 use Shopware\Cart\Price\PriceDefinition;
 use Shopware\Cart\Tax\TaxDetector;
@@ -123,8 +122,8 @@ class Generator extends TestCase
             $fallbackCustomerGroup,
             $taxes,
             $priceGroupDiscounts,
-            new PaymentMethodBasicStruct(1, '', '', ''),
-            new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+            new PaymentMethodBasicStruct(),
+            new ShippingMethodBasicStruct(),
             ShippingLocation::createFromAddress($shipping),
             new CustomerBasicStruct()
         );

--- a/src/Cart/Test/Domain/Cart/CalculatedCartGeneratorTest.php
+++ b/src/Cart/Test/Domain/Cart/CalculatedCartGeneratorTest.php
@@ -30,12 +30,10 @@ use Shopware\Cart\Cart\CalculatedCartGenerator;
 use Shopware\Cart\Cart\CartContainer;
 use Shopware\Cart\Cart\ProcessorCart;
 use Shopware\Cart\Delivery\Delivery;
-use Shopware\Cart\Delivery\DeliveryCalculator;
 use Shopware\Cart\Delivery\DeliveryCollection;
 use Shopware\Cart\Delivery\DeliveryDate;
 use Shopware\Cart\Delivery\DeliveryPositionCollection;
 use Shopware\Cart\Delivery\ShippingLocation;
-use Shopware\Cart\Error\ErrorCollection;
 use Shopware\Cart\Error\VoucherNotFoundError;
 use Shopware\Cart\LineItem\CalculatedLineItemCollection;
 use Shopware\Cart\Price\AmountCalculator;
@@ -72,8 +70,7 @@ class CalculatedCartGeneratorTest extends TestCase
                 $container,
                 new CalculatedLineItemCollection(),
                 $price,
-                new DeliveryCollection(),
-                new ErrorCollection()
+                new DeliveryCollection()
             ),
             $generator->create($container, $context, $processorCart)
         );
@@ -119,7 +116,7 @@ class CalculatedCartGeneratorTest extends TestCase
         $delivery = new Delivery(
             new DeliveryPositionCollection(),
             new DeliveryDate(new \DateTime(), new \DateTime()),
-            new ShippingMethodBasicStruct(1, 'prime', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+            new ShippingMethodBasicStruct(),
             $this->createMock(ShippingLocation::class),
             new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
         );

--- a/src/Cart/Test/Domain/Delivery/DeliveryCollectionTest.php
+++ b/src/Cart/Test/Domain/Delivery/DeliveryCollectionTest.php
@@ -27,7 +27,6 @@ namespace Shopware\Cart\Test\Domain\Delivery;
 use PHPUnit\Framework\TestCase;
 use Shopware\AreaCountry\Struct\AreaCountryBasicStruct;
 use Shopware\Cart\Delivery\Delivery;
-use Shopware\Cart\Delivery\DeliveryCalculator;
 use Shopware\Cart\Delivery\DeliveryCollection;
 use Shopware\Cart\Delivery\DeliveryDate;
 use Shopware\Cart\Delivery\DeliveryPositionCollection;
@@ -56,7 +55,7 @@ class DeliveryCollectionTest extends TestCase
                     new \DateTime(),
                     new \DateTime()
                 ),
-                new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                new ShippingMethodBasicStruct(),
                 self::createShippingLocation(),
                 new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
             )
@@ -73,7 +72,7 @@ class DeliveryCollectionTest extends TestCase
                     new \DateTime(),
                     new \DateTime()
                 ),
-                new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                new ShippingMethodBasicStruct(),
                 self::createShippingLocation(),
                 new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
             ),
@@ -83,7 +82,7 @@ class DeliveryCollectionTest extends TestCase
                     new \DateTime(),
                     new \DateTime()
                 ),
-                new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                new ShippingMethodBasicStruct(),
                 self::createShippingLocation(),
                 new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
             ),
@@ -100,7 +99,7 @@ class DeliveryCollectionTest extends TestCase
                     new \DateTime(),
                     new \DateTime()
                 ),
-                new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                new ShippingMethodBasicStruct(),
                 self::createShippingLocation(),
                 new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
             ),
@@ -110,7 +109,7 @@ class DeliveryCollectionTest extends TestCase
                     new \DateTime(),
                     new \DateTime()
                 ),
-                new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                new ShippingMethodBasicStruct(),
                 self::createShippingLocation(),
                 new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
             ),

--- a/src/Cart/Test/Domain/Delivery/StockDeliverySeparatorTest.php
+++ b/src/Cart/Test/Domain/Delivery/StockDeliverySeparatorTest.php
@@ -28,7 +28,6 @@ use PHPUnit\Framework\TestCase;
 use Shopware\AreaCountry\Struct\AreaCountryBasicStruct;
 use Shopware\AreaCountryState\Struct\AreaCountryStateBasicStruct;
 use Shopware\Cart\Delivery\Delivery;
-use Shopware\Cart\Delivery\DeliveryCalculator;
 use Shopware\Cart\Delivery\DeliveryCollection;
 use Shopware\Cart\Delivery\DeliveryDate;
 use Shopware\Cart\Delivery\DeliveryInformation;
@@ -114,7 +113,7 @@ class StockDeliverySeparatorTest extends TestCase
                         DeliveryPosition::createByLineItemForInStockDate($item),
                     ]),
                     new DeliveryDate(new \DateTime('2012-01-01'), new \DateTime('2012-01-02')),
-                    new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                    new ShippingMethodBasicStruct(),
                     $location,
                     new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
                 ),
@@ -165,7 +164,7 @@ class StockDeliverySeparatorTest extends TestCase
                         DeliveryPosition::createByLineItemForInStockDate($itemB),
                     ]),
                     $deliveryInformation->getInStockDeliveryDate(),
-                    new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                    new ShippingMethodBasicStruct(),
                     $location,
                     new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
                 ),
@@ -207,7 +206,7 @@ class StockDeliverySeparatorTest extends TestCase
                         DeliveryPosition::createByLineItemForOutOfStockDate($itemB),
                     ]),
                     new DeliveryDate(new \DateTime('2012-01-04'), new \DateTime('2012-01-05')),
-                    new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                    new ShippingMethodBasicStruct(),
                     $location,
                     new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
                 ),
@@ -247,7 +246,7 @@ class StockDeliverySeparatorTest extends TestCase
                         DeliveryPosition::createByLineItemForInStockDate($product),
                     ]),
                     $product->getInStockDeliveryDate(),
-                    new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                    new ShippingMethodBasicStruct(),
                     $location,
                     new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
                 ),
@@ -284,7 +283,7 @@ class StockDeliverySeparatorTest extends TestCase
                         ),
                     ]),
                     $product->getInStockDeliveryDate(),
-                    new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                    new ShippingMethodBasicStruct(),
                     $location,
                     new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
                 ),
@@ -296,7 +295,7 @@ class StockDeliverySeparatorTest extends TestCase
                         ),
                     ]),
                     $product->getOutOfStockDeliveryDate(),
-                    new ShippingMethodBasicStruct(1, '', DeliveryCalculator::CALCULATION_BY_WEIGHT, true, 1),
+                    new ShippingMethodBasicStruct(),
                     $location,
                     new Price(0, 0, new CalculatedTaxCollection(), new TaxRuleCollection())
                 ),

--- a/src/Cart/Test/Domain/Tax/TaxCalculatorTest.php
+++ b/src/Cart/Test/Domain/Tax/TaxCalculatorTest.php
@@ -32,17 +32,16 @@ use Shopware\Cart\Tax\TaxRule;
 use Shopware\Cart\Tax\TaxRuleCalculator;
 use Shopware\Cart\Tax\TaxRuleCollection;
 use Shopware\Cart\Tax\TaxRuleInterface;
-use Shopware\Tax\Struct\Tax;
 
 class TaxCalculatorTest extends TestCase
 {
     /**
      * @dataProvider netPricesToGross
      *
-     * @param float                $expected
-     * @param PriceRounding        $rounding
-     * @param TaxRuleInterface|Tax $taxRule
-     * @param float                $net
+     * @param float            $expected
+     * @param PriceRounding    $rounding
+     * @param TaxRuleInterface $taxRule
+     * @param float            $net
      */
     public function testCalculateGrossPriceOfNetPrice($expected, PriceRounding $rounding, TaxRuleInterface $taxRule, $net): void
     {

--- a/src/Cart/Test/Infrastructure/Validator/Collector/OrderClearedStateRuleCollectorTest.php
+++ b/src/Cart/Test/Infrastructure/Validator/Collector/OrderClearedStateRuleCollectorTest.php
@@ -91,11 +91,10 @@ class OrderClearedStateRuleCollectorTest extends TestCase
 
         $this->assertSame(2, $dataCollection->count());
 
+        /* @var OrderClearedStateRuleData $rule */
         $rule = $dataCollection->get(OrderClearedStateRuleData::class);
 
         $this->assertInstanceOf(OrderClearedStateRuleData::class, $rule);
-
-        /* @var OrderClearedStateRuleData $rule */
         $this->assertSame([1], $rule->getStates());
     }
 

--- a/src/Cart/Test/Infrastructure/Validator/Rule/IsNewCustomerRuleTest.php
+++ b/src/Cart/Test/Infrastructure/Validator/Rule/IsNewCustomerRuleTest.php
@@ -62,7 +62,7 @@ class IsNewCustomerRuleTest extends TestCase
         $customer = new CustomerBasicStruct();
         $customer->setFirstLogin(
             (new \DateTime())->sub(
-                new \DateInterval('P' . (int) 10 . 'D')
+                new \DateInterval('P' . 10 . 'D')
             )
         );
 
@@ -86,7 +86,7 @@ class IsNewCustomerRuleTest extends TestCase
         $customer = new CustomerBasicStruct();
         $customer->setFirstLogin(
             (new \DateTime())->add(
-                new \DateInterval('P' . (int) 10 . 'D')
+                new \DateInterval('P' . 10 . 'D')
             )
         );
 

--- a/src/Cart/Test/Infrastructure/Validator/Rule/LastOrderRuleTest.php
+++ b/src/Cart/Test/Infrastructure/Validator/Rule/LastOrderRuleTest.php
@@ -42,7 +42,7 @@ class LastOrderRuleTest extends TestCase
         $context = $this->createMock(ShopContext::class);
 
         $date = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) 10 . 'D')
+            new \DateInterval('P' . 10 . 'D')
         );
 
         $this->assertTrue(
@@ -61,7 +61,7 @@ class LastOrderRuleTest extends TestCase
         $context = $this->createMock(ShopContext::class);
 
         $date = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) 9 . 'D')
+            new \DateInterval('P' . 9 . 'D')
         );
 
         $this->assertFalse(
@@ -80,7 +80,7 @@ class LastOrderRuleTest extends TestCase
         $context = $this->createMock(ShopContext::class);
 
         $date = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) 50 . 'D')
+            new \DateInterval('P' . 50 . 'D')
         );
 
         $this->assertTrue(

--- a/src/Cart/Test/Infrastructure/Validator/Rule/RecentOrderRuleTest.php
+++ b/src/Cart/Test/Infrastructure/Validator/Rule/RecentOrderRuleTest.php
@@ -42,7 +42,7 @@ class RecentOrderRuleTest extends TestCase
         $context = $this->createMock(ShopContext::class);
 
         $date = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) 10 . 'D')
+            new \DateInterval('P' . 10 . 'D')
         );
 
         $this->assertTrue(
@@ -61,7 +61,7 @@ class RecentOrderRuleTest extends TestCase
         $context = $this->createMock(ShopContext::class);
 
         $date = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) 9 . 'D')
+            new \DateInterval('P' . 9 . 'D')
         );
 
         $this->assertFalse(
@@ -80,7 +80,7 @@ class RecentOrderRuleTest extends TestCase
         $context = $this->createMock(ShopContext::class);
 
         $date = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) 50 . 'D')
+            new \DateInterval('P' . 50 . 'D')
         );
 
         $this->assertTrue(

--- a/src/CartBridge/Rule/BillingZipCodeRule.php
+++ b/src/CartBridge/Rule/BillingZipCodeRule.php
@@ -38,7 +38,7 @@ class BillingZipCodeRule extends Rule
     protected $zipCodes;
 
     /**
-     * @param \string[] $zipCodes
+     * @param string[] $zipCodes
      */
     public function __construct(array $zipCodes)
     {

--- a/src/CartBridge/Rule/LastNameRule.php
+++ b/src/CartBridge/Rule/LastNameRule.php
@@ -52,7 +52,7 @@ class LastNameRule extends Rule
         }
 
         return new Match(
-            (bool) preg_match("/$this->lastName/", strtolower($customer->getLastname())),
+            (bool) preg_match("/$this->lastName/", strtolower($customer->getLastName())),
             ['Last name not matched']
         );
     }

--- a/src/CartBridge/Rule/LastOrderRule.php
+++ b/src/CartBridge/Rule/LastOrderRule.php
@@ -56,7 +56,7 @@ class LastOrderRule extends Rule
         $data = $collection->get(LastOrderRuleData::class);
 
         $min = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) $this->days . 'D')
+            new \DateInterval('P' . $this->days . 'D')
         );
 
         return new Match(

--- a/src/CartBridge/Rule/ProductOfManufacturerRule.php
+++ b/src/CartBridge/Rule/ProductOfManufacturerRule.php
@@ -32,7 +32,7 @@ use Shopware\Framework\Struct\StructCollection;
 class ProductOfManufacturerRule extends Rule
 {
     /**
-     * @var int[]
+     * @var string[]
      */
     protected $manufacturerIds;
 
@@ -42,7 +42,7 @@ class ProductOfManufacturerRule extends Rule
     }
 
     /**
-     * @return \int[]
+     * @return string[]
      */
     public function getManufacturerIds(): array
     {

--- a/src/CartBridge/Rule/RecentOrderRule.php
+++ b/src/CartBridge/Rule/RecentOrderRule.php
@@ -55,7 +55,7 @@ class RecentOrderRule extends \Shopware\Cart\Rule\Rule
         $data = $collection->get(RecentOrderRuleData::class);
 
         $min = (new \DateTime())->sub(
-            new \DateInterval('P' . (int) $this->days . 'D')
+            new \DateInterval('P' . $this->days . 'D')
         );
 
         return new Match(

--- a/src/Category/Extension/CategoryExtension.php
+++ b/src/Category/Extension/CategoryExtension.php
@@ -2,15 +2,15 @@
 
 namespace Shopware\Category\Extension;
 
+use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Category\Event\CategoryBasicLoadedEvent;
 use Shopware\Category\Event\CategoryDetailLoadedEvent;
 use Shopware\Category\Event\CategoryWrittenEvent;
-use Shopware\Category\Struct\CategoryBasicStruct;
-use Shopware\Context\Struct\TranslationContext;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Category\Struct\CategoryBasicStruct;
 
 abstract class CategoryExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class CategoryExtension implements ExtensionInterface, EventSubscriberI
         return [
             CategoryBasicLoadedEvent::NAME => 'categoryBasicLoaded',
             CategoryDetailLoadedEvent::NAME => 'categoryDetailLoaded',
-            CategoryWrittenEvent::NAME => 'categoryWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class CategoryExtension implements ExtensionInterface, EventSubscriberI
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class CategoryExtension implements ExtensionInterface, EventSubscriberI
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function categoryBasicLoaded(CategoryBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function categoryDetailLoaded(CategoryDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function categoryWritten(CategoryWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/Currency/Extension/CurrencyExtension.php
+++ b/src/Currency/Extension/CurrencyExtension.php
@@ -3,14 +3,14 @@
 namespace Shopware\Currency\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Currency\Event\CurrencyBasicLoadedEvent;
 use Shopware\Currency\Event\CurrencyDetailLoadedEvent;
 use Shopware\Currency\Event\CurrencyWrittenEvent;
-use Shopware\Currency\Struct\CurrencyBasicStruct;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Currency\Struct\CurrencyBasicStruct;
 
 abstract class CurrencyExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class CurrencyExtension implements ExtensionInterface, EventSubscriberI
         return [
             CurrencyBasicLoadedEvent::NAME => 'currencyBasicLoaded',
             CurrencyDetailLoadedEvent::NAME => 'currencyDetailLoaded',
-            CurrencyWrittenEvent::NAME => 'currencyWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class CurrencyExtension implements ExtensionInterface, EventSubscriberI
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class CurrencyExtension implements ExtensionInterface, EventSubscriberI
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function currencyBasicLoaded(CurrencyBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function currencyDetailLoaded(CurrencyDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function currencyWritten(CurrencyWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/Customer/Extension/CustomerExtension.php
+++ b/src/Customer/Extension/CustomerExtension.php
@@ -3,14 +3,14 @@
 namespace Shopware\Customer\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Customer\Event\CustomerBasicLoadedEvent;
 use Shopware\Customer\Event\CustomerDetailLoadedEvent;
 use Shopware\Customer\Event\CustomerWrittenEvent;
-use Shopware\Customer\Struct\CustomerBasicStruct;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Customer\Struct\CustomerBasicStruct;
 
 abstract class CustomerExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class CustomerExtension implements ExtensionInterface, EventSubscriberI
         return [
             CustomerBasicLoadedEvent::NAME => 'customerBasicLoaded',
             CustomerDetailLoadedEvent::NAME => 'customerDetailLoaded',
-            CustomerWrittenEvent::NAME => 'customerWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class CustomerExtension implements ExtensionInterface, EventSubscriberI
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class CustomerExtension implements ExtensionInterface, EventSubscriberI
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function customerBasicLoaded(CustomerBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function customerDetailLoaded(CustomerDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function customerWritten(CustomerWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/CustomerAddress/Controller/CustomerAddressController.php
+++ b/src/CustomerAddress/Controller/CustomerAddressController.php
@@ -190,7 +190,7 @@ class CustomerAddressController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $customerAddresses = $this->customerAddressRepository->readDetail(
+        $customerAddresses = $this->customerAddressRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/CustomerAddress/Extension/CustomerAddressExtension.php
+++ b/src/CustomerAddress/Extension/CustomerAddressExtension.php
@@ -3,13 +3,13 @@
 namespace Shopware\CustomerAddress\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\CustomerAddress\Event\CustomerAddressBasicLoadedEvent;
 use Shopware\CustomerAddress\Event\CustomerAddressWrittenEvent;
-use Shopware\CustomerAddress\Struct\CustomerAddressBasicStruct;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\CustomerAddress\Struct\CustomerAddressBasicStruct;
 
 abstract class CustomerAddressExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class CustomerAddressExtension implements ExtensionInterface, EventSubs
     {
         return [
             CustomerAddressBasicLoadedEvent::NAME => 'customerAddressBasicLoaded',
-            CustomerAddressWrittenEvent::NAME => 'customerAddressWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class CustomerAddressExtension implements ExtensionInterface, EventSubs
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class CustomerAddressExtension implements ExtensionInterface, EventSubs
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function customerAddressBasicLoaded(CustomerAddressBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function customerAddressWritten(CustomerAddressWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/CustomerGroup/Extension/CustomerGroupExtension.php
+++ b/src/CustomerGroup/Extension/CustomerGroupExtension.php
@@ -3,14 +3,14 @@
 namespace Shopware\CustomerGroup\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\CustomerGroup\Event\CustomerGroupBasicLoadedEvent;
 use Shopware\CustomerGroup\Event\CustomerGroupDetailLoadedEvent;
 use Shopware\CustomerGroup\Event\CustomerGroupWrittenEvent;
-use Shopware\CustomerGroup\Struct\CustomerGroupBasicStruct;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\CustomerGroup\Struct\CustomerGroupBasicStruct;
 
 abstract class CustomerGroupExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class CustomerGroupExtension implements ExtensionInterface, EventSubscr
         return [
             CustomerGroupBasicLoadedEvent::NAME => 'customerGroupBasicLoaded',
             CustomerGroupDetailLoadedEvent::NAME => 'customerGroupDetailLoaded',
-            CustomerGroupWrittenEvent::NAME => 'customerGroupWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class CustomerGroupExtension implements ExtensionInterface, EventSubscr
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class CustomerGroupExtension implements ExtensionInterface, EventSubscr
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function customerGroupBasicLoaded(CustomerGroupBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function customerGroupDetailLoaded(CustomerGroupDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function customerGroupWritten(CustomerGroupWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/CustomerGroupDiscount/Controller/CustomerGroupDiscountController.php
+++ b/src/CustomerGroupDiscount/Controller/CustomerGroupDiscountController.php
@@ -190,7 +190,7 @@ class CustomerGroupDiscountController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $customerGroupDiscounts = $this->customerGroupDiscountRepository->readDetail(
+        $customerGroupDiscounts = $this->customerGroupDiscountRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/CustomerGroupDiscount/Extension/CustomerGroupDiscountExtension.php
+++ b/src/CustomerGroupDiscount/Extension/CustomerGroupDiscountExtension.php
@@ -3,13 +3,13 @@
 namespace Shopware\CustomerGroupDiscount\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
+use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\CustomerGroupDiscount\Event\CustomerGroupDiscountBasicLoadedEvent;
 use Shopware\CustomerGroupDiscount\Event\CustomerGroupDiscountWrittenEvent;
-use Shopware\CustomerGroupDiscount\Struct\CustomerGroupDiscountBasicStruct;
-use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\CustomerGroupDiscount\Struct\CustomerGroupDiscountBasicStruct;
 
 abstract class CustomerGroupDiscountExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class CustomerGroupDiscountExtension implements ExtensionInterface, Eve
     {
         return [
             CustomerGroupDiscountBasicLoadedEvent::NAME => 'customerGroupDiscountBasicLoaded',
-            CustomerGroupDiscountWrittenEvent::NAME => 'customerGroupDiscountWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class CustomerGroupDiscountExtension implements ExtensionInterface, Eve
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class CustomerGroupDiscountExtension implements ExtensionInterface, Eve
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function customerGroupDiscountBasicLoaded(CustomerGroupDiscountBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function customerGroupDiscountWritten(CustomerGroupDiscountWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Framework/Migration/Manager.php
+++ b/src/Framework/Migration/Manager.php
@@ -143,24 +143,6 @@ class Manager
     }
 
     /**
-     * Returns next Migration that is higher than $currentVersion
-     *
-     * @param int $currentVersion
-     *
-     * @return AbstractMigration
-     */
-    public function getNextMigrationForVersion($currentVersion)
-    {
-        $migrations = $this->getMigrationsForVersion($currentVersion, 1);
-
-        if (empty($migrations)) {
-            return null;
-        }
-
-        return array_shift($migrations);
-    }
-
-    /**
      * Return an array of Migrations that have a higher version than $currentVersion
      * The array is indexed by Version
      *

--- a/src/Framework/Validation/ValidationException.php
+++ b/src/Framework/Validation/ValidationException.php
@@ -22,15 +22,14 @@
  * our trademarks remain entirely with us.
  */
 
-namespace Shopware\B2B\Common\Validator;
+namespace Shopware\Framework\Validation;
 
 use Exception;
-use Shopware\B2B\Common\B2BException;
-use Shopware\B2B\Common\Entity;
+use Shopware\Framework\ShopwareException;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
-class ValidationException extends \InvalidArgumentException implements B2BException
+class ValidationException extends \InvalidArgumentException implements ShopwareException
 {
     /**
      * @var ConstraintViolationListInterface
@@ -43,19 +42,12 @@ class ValidationException extends \InvalidArgumentException implements B2BExcept
     private $sortedViolations = [];
 
     /**
-     * @var Entity
-     */
-    private $entity;
-
-    /**
-     * @param Entity                           $entity
      * @param ConstraintViolationListInterface $violations
      * @param string                           $message
      * @param null                             $code
      * @param Exception|null                   $previous
      */
     public function __construct(
-        Entity $entity,
         ConstraintViolationListInterface $violations,
         $message,
         $code = null,
@@ -78,7 +70,6 @@ class ValidationException extends \InvalidArgumentException implements B2BExcept
         parent::__construct($message . "\n\t" . implode("\n\t<br>", $readableViolationList), $code, $previous);
 
         $this->violations = $violations;
-        $this->entity = $entity;
     }
 
     /**
@@ -109,13 +100,5 @@ class ValidationException extends \InvalidArgumentException implements B2BExcept
     public function getViolations()
     {
         return $this->violations;
-    }
-
-    /**
-     * @return Entity
-     */
-    public function getEntity(): Entity
-    {
-        return $this->entity;
     }
 }

--- a/src/Framework/Write/Field/UuidField.php
+++ b/src/Framework/Write/Field/UuidField.php
@@ -45,7 +45,7 @@ class UuidField extends Field implements WriteContextAware, ResourceAware, UuidG
     private $writeContext;
 
     /**
-     * @var WriterResource
+     * @var WriteResource
      */
     private $resource;
 

--- a/src/Framework/Write/Query/WriteTypeIntendException.php
+++ b/src/Framework/Write/Query/WriteTypeIntendException.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Shopware\Write\Query;
 

--- a/src/Framework/Write/SqlGateway.php
+++ b/src/Framework/Write/SqlGateway.php
@@ -56,11 +56,9 @@ class SqlGateway
             $qb->setParameter($pkDatum, $pkValue);
         }
 
-        $ret = (bool) $qb
+        return (bool) $qb
             ->execute()
             ->fetchColumn();
-
-        return $ret;
     }
 
     /**
@@ -68,7 +66,6 @@ class SqlGateway
      */
     public function insert(string $tableName, array $data): void
     {
-        //        $this->connection->transactional(function() use ($data, $tableName) {
         $affectedRows = $this->connection->insert(
             QuerySelection::escape($tableName),
             $data
@@ -77,7 +74,6 @@ class SqlGateway
         if (!$affectedRows) {
             throw new ExceptionNoInsertedRecord('Unable to insert data');
         }
-        //        });
     }
 
     /**
@@ -86,7 +82,6 @@ class SqlGateway
      */
     public function update(string $tableName, array $uuid, array $data): void
     {
-        //        $this->connection->transactional(function() use ($uuid, $data, $tableName) {
         $affectedRows = $this->connection->update(
             QuerySelection::escape($tableName),
             $data,
@@ -101,6 +96,5 @@ class SqlGateway
         if ($affectedRows > 1) {
             throw new ExceptionMultipleUpdatedRecord(sprintf('Unable to update "%s" - multiple rows updated', $uuid));
         }
-        //        });
     }
 }

--- a/src/Holiday/Controller/HolidayController.php
+++ b/src/Holiday/Controller/HolidayController.php
@@ -190,7 +190,7 @@ class HolidayController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $holidays = $this->holidayRepository->readDetail(
+        $holidays = $this->holidayRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/Holiday/Extension/HolidayExtension.php
+++ b/src/Holiday/Extension/HolidayExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Holiday\Event\HolidayBasicLoadedEvent;
 use Shopware\Holiday\Event\HolidayWrittenEvent;
-use Shopware\Holiday\Struct\HolidayBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Holiday\Struct\HolidayBasicStruct;
 
 abstract class HolidayExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class HolidayExtension implements ExtensionInterface, EventSubscriberIn
     {
         return [
             HolidayBasicLoadedEvent::NAME => 'holidayBasicLoaded',
-            HolidayWrittenEvent::NAME => 'holidayWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class HolidayExtension implements ExtensionInterface, EventSubscriberIn
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class HolidayExtension implements ExtensionInterface, EventSubscriberIn
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function holidayBasicLoaded(HolidayBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function holidayWritten(HolidayWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ListingSorting/Controller/ListingSortingController.php
+++ b/src/ListingSorting/Controller/ListingSortingController.php
@@ -190,7 +190,7 @@ class ListingSortingController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $listingSortings = $this->listingSortingRepository->readDetail(
+        $listingSortings = $this->listingSortingRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ListingSorting/Extension/ListingSortingExtension.php
+++ b/src/ListingSorting/Extension/ListingSortingExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ListingSorting\Event\ListingSortingBasicLoadedEvent;
 use Shopware\ListingSorting\Event\ListingSortingWrittenEvent;
-use Shopware\ListingSorting\Struct\ListingSortingBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ListingSorting\Struct\ListingSortingBasicStruct;
 
 abstract class ListingSortingExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ListingSortingExtension implements ExtensionInterface, EventSubsc
     {
         return [
             ListingSortingBasicLoadedEvent::NAME => 'listingSortingBasicLoaded',
-            ListingSortingWrittenEvent::NAME => 'listingSortingWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ListingSortingExtension implements ExtensionInterface, EventSubsc
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ListingSortingExtension implements ExtensionInterface, EventSubsc
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function listingSortingBasicLoaded(ListingSortingBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function listingSortingWritten(ListingSortingWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Locale/Controller/LocaleController.php
+++ b/src/Locale/Controller/LocaleController.php
@@ -190,7 +190,7 @@ class LocaleController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $locales = $this->localeRepository->readDetail(
+        $locales = $this->localeRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/Locale/Extension/LocaleExtension.php
+++ b/src/Locale/Extension/LocaleExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Locale\Event\LocaleBasicLoadedEvent;
 use Shopware\Locale\Event\LocaleWrittenEvent;
-use Shopware\Locale\Struct\LocaleBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Locale\Struct\LocaleBasicStruct;
 
 abstract class LocaleExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class LocaleExtension implements ExtensionInterface, EventSubscriberInt
     {
         return [
             LocaleBasicLoadedEvent::NAME => 'localeBasicLoaded',
-            LocaleWrittenEvent::NAME => 'localeWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class LocaleExtension implements ExtensionInterface, EventSubscriberInt
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class LocaleExtension implements ExtensionInterface, EventSubscriberInt
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function localeBasicLoaded(LocaleBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function localeWritten(LocaleWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Media/Commands/MediaOptimizeCommand.php
+++ b/src/Media/Commands/MediaOptimizeCommand.php
@@ -85,7 +85,7 @@ class MediaOptimizeCommand extends Command
         if ($input->getOption('info')) {
             $this->displayCapabilities();
 
-            return;
+            return null;
         }
 
         $finder = $this->createMediaFinder($input, $output);

--- a/src/Media/Controller/MediaController.php
+++ b/src/Media/Controller/MediaController.php
@@ -190,7 +190,7 @@ class MediaController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $media = $this->mediaRepository->readDetail(
+        $media = $this->mediaRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/Media/Extension/MediaExtension.php
+++ b/src/Media/Extension/MediaExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Media\Event\MediaBasicLoadedEvent;
 use Shopware\Media\Event\MediaWrittenEvent;
-use Shopware\Media\Struct\MediaBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Media\Struct\MediaBasicStruct;
 
 abstract class MediaExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class MediaExtension implements ExtensionInterface, EventSubscriberInte
     {
         return [
             MediaBasicLoadedEvent::NAME => 'mediaBasicLoaded',
-            MediaWrittenEvent::NAME => 'mediaWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class MediaExtension implements ExtensionInterface, EventSubscriberInte
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class MediaExtension implements ExtensionInterface, EventSubscriberInte
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function mediaBasicLoaded(MediaBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function mediaWritten(MediaWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Media/GarbageCollector.php
+++ b/src/Media/GarbageCollector.php
@@ -45,7 +45,7 @@ class GarbageCollector
     private $connection;
 
     /**
-     * @var UrlGeneratorInterface
+     * @var StrategyInterface
      */
     private $strategy;
 

--- a/src/Order/Extension/OrderExtension.php
+++ b/src/Order/Extension/OrderExtension.php
@@ -7,10 +7,10 @@ use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Order\Event\OrderBasicLoadedEvent;
 use Shopware\Order\Event\OrderDetailLoadedEvent;
 use Shopware\Order\Event\OrderWrittenEvent;
-use Shopware\Order\Struct\OrderBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Order\Struct\OrderBasicStruct;
 
 abstract class OrderExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class OrderExtension implements ExtensionInterface, EventSubscriberInte
         return [
             OrderBasicLoadedEvent::NAME => 'orderBasicLoaded',
             OrderDetailLoadedEvent::NAME => 'orderDetailLoaded',
-            OrderWrittenEvent::NAME => 'orderWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class OrderExtension implements ExtensionInterface, EventSubscriberInte
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class OrderExtension implements ExtensionInterface, EventSubscriberInte
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function orderBasicLoaded(OrderBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function orderDetailLoaded(OrderDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function orderWritten(OrderWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/OrderAddress/Controller/OrderAddressController.php
+++ b/src/OrderAddress/Controller/OrderAddressController.php
@@ -190,7 +190,7 @@ class OrderAddressController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $orderAddresses = $this->orderAddressRepository->readDetail(
+        $orderAddresses = $this->orderAddressRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/OrderAddress/Extension/OrderAddressExtension.php
+++ b/src/OrderAddress/Extension/OrderAddressExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\OrderAddress\Event\OrderAddressBasicLoadedEvent;
 use Shopware\OrderAddress\Event\OrderAddressWrittenEvent;
-use Shopware\OrderAddress\Struct\OrderAddressBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\OrderAddress\Struct\OrderAddressBasicStruct;
 
 abstract class OrderAddressExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class OrderAddressExtension implements ExtensionInterface, EventSubscri
     {
         return [
             OrderAddressBasicLoadedEvent::NAME => 'orderAddressBasicLoaded',
-            OrderAddressWrittenEvent::NAME => 'orderAddressWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class OrderAddressExtension implements ExtensionInterface, EventSubscri
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class OrderAddressExtension implements ExtensionInterface, EventSubscri
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function orderAddressBasicLoaded(OrderAddressBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function orderAddressWritten(OrderAddressWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/OrderDelivery/Extension/OrderDeliveryExtension.php
+++ b/src/OrderDelivery/Extension/OrderDeliveryExtension.php
@@ -7,10 +7,10 @@ use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\OrderDelivery\Event\OrderDeliveryBasicLoadedEvent;
 use Shopware\OrderDelivery\Event\OrderDeliveryDetailLoadedEvent;
 use Shopware\OrderDelivery\Event\OrderDeliveryWrittenEvent;
-use Shopware\OrderDelivery\Struct\OrderDeliveryBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\OrderDelivery\Struct\OrderDeliveryBasicStruct;
 
 abstract class OrderDeliveryExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class OrderDeliveryExtension implements ExtensionInterface, EventSubscr
         return [
             OrderDeliveryBasicLoadedEvent::NAME => 'orderDeliveryBasicLoaded',
             OrderDeliveryDetailLoadedEvent::NAME => 'orderDeliveryDetailLoaded',
-            OrderDeliveryWrittenEvent::NAME => 'orderDeliveryWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class OrderDeliveryExtension implements ExtensionInterface, EventSubscr
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class OrderDeliveryExtension implements ExtensionInterface, EventSubscr
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function orderDeliveryBasicLoaded(OrderDeliveryBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function orderDeliveryDetailLoaded(OrderDeliveryDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function orderDeliveryWritten(OrderDeliveryWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/OrderDeliveryPosition/Controller/OrderDeliveryPositionController.php
+++ b/src/OrderDeliveryPosition/Controller/OrderDeliveryPositionController.php
@@ -190,7 +190,7 @@ class OrderDeliveryPositionController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $orderDeliveryPositions = $this->orderDeliveryPositionRepository->readDetail(
+        $orderDeliveryPositions = $this->orderDeliveryPositionRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/OrderDeliveryPosition/Extension/OrderDeliveryPositionExtension.php
+++ b/src/OrderDeliveryPosition/Extension/OrderDeliveryPositionExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\OrderDeliveryPosition\Event\OrderDeliveryPositionBasicLoadedEvent;
 use Shopware\OrderDeliveryPosition\Event\OrderDeliveryPositionWrittenEvent;
-use Shopware\OrderDeliveryPosition\Struct\OrderDeliveryPositionBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\OrderDeliveryPosition\Struct\OrderDeliveryPositionBasicStruct;
 
 abstract class OrderDeliveryPositionExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class OrderDeliveryPositionExtension implements ExtensionInterface, Eve
     {
         return [
             OrderDeliveryPositionBasicLoadedEvent::NAME => 'orderDeliveryPositionBasicLoaded',
-            OrderDeliveryPositionWrittenEvent::NAME => 'orderDeliveryPositionWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class OrderDeliveryPositionExtension implements ExtensionInterface, Eve
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class OrderDeliveryPositionExtension implements ExtensionInterface, Eve
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function orderDeliveryPositionBasicLoaded(OrderDeliveryPositionBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function orderDeliveryPositionWritten(OrderDeliveryPositionWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/OrderLineItem/Controller/OrderLineItemController.php
+++ b/src/OrderLineItem/Controller/OrderLineItemController.php
@@ -190,7 +190,7 @@ class OrderLineItemController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $orderLineItems = $this->orderLineItemRepository->readDetail(
+        $orderLineItems = $this->orderLineItemRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/OrderLineItem/Extension/OrderLineItemExtension.php
+++ b/src/OrderLineItem/Extension/OrderLineItemExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\OrderLineItem\Event\OrderLineItemBasicLoadedEvent;
 use Shopware\OrderLineItem\Event\OrderLineItemWrittenEvent;
-use Shopware\OrderLineItem\Struct\OrderLineItemBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\OrderLineItem\Struct\OrderLineItemBasicStruct;
 
 abstract class OrderLineItemExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class OrderLineItemExtension implements ExtensionInterface, EventSubscr
     {
         return [
             OrderLineItemBasicLoadedEvent::NAME => 'orderLineItemBasicLoaded',
-            OrderLineItemWrittenEvent::NAME => 'orderLineItemWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class OrderLineItemExtension implements ExtensionInterface, EventSubscr
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class OrderLineItemExtension implements ExtensionInterface, EventSubscr
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function orderLineItemBasicLoaded(OrderLineItemBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function orderLineItemWritten(OrderLineItemWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/OrderState/Controller/OrderStateController.php
+++ b/src/OrderState/Controller/OrderStateController.php
@@ -190,7 +190,7 @@ class OrderStateController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $orderStates = $this->orderStateRepository->readDetail(
+        $orderStates = $this->orderStateRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/OrderState/Extension/OrderStateExtension.php
+++ b/src/OrderState/Extension/OrderStateExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\OrderState\Event\OrderStateBasicLoadedEvent;
 use Shopware\OrderState\Event\OrderStateWrittenEvent;
-use Shopware\OrderState\Struct\OrderStateBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\OrderState\Struct\OrderStateBasicStruct;
 
 abstract class OrderStateExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class OrderStateExtension implements ExtensionInterface, EventSubscribe
     {
         return [
             OrderStateBasicLoadedEvent::NAME => 'orderStateBasicLoaded',
-            OrderStateWrittenEvent::NAME => 'orderStateWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class OrderStateExtension implements ExtensionInterface, EventSubscribe
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class OrderStateExtension implements ExtensionInterface, EventSubscribe
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function orderStateBasicLoaded(OrderStateBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function orderStateWritten(OrderStateWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/PaymentMethod/Extension/PaymentMethodExtension.php
+++ b/src/PaymentMethod/Extension/PaymentMethodExtension.php
@@ -7,10 +7,10 @@ use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\PaymentMethod\Event\PaymentMethodBasicLoadedEvent;
 use Shopware\PaymentMethod\Event\PaymentMethodDetailLoadedEvent;
 use Shopware\PaymentMethod\Event\PaymentMethodWrittenEvent;
-use Shopware\PaymentMethod\Struct\PaymentMethodBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\PaymentMethod\Struct\PaymentMethodBasicStruct;
 
 abstract class PaymentMethodExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class PaymentMethodExtension implements ExtensionInterface, EventSubscr
         return [
             PaymentMethodBasicLoadedEvent::NAME => 'paymentMethodBasicLoaded',
             PaymentMethodDetailLoadedEvent::NAME => 'paymentMethodDetailLoaded',
-            PaymentMethodWrittenEvent::NAME => 'paymentMethodWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class PaymentMethodExtension implements ExtensionInterface, EventSubscr
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class PaymentMethodExtension implements ExtensionInterface, EventSubscr
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function paymentMethodBasicLoaded(PaymentMethodBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function paymentMethodDetailLoaded(PaymentMethodDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function paymentMethodWritten(PaymentMethodWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/PriceGroup/Extension/PriceGroupExtension.php
+++ b/src/PriceGroup/Extension/PriceGroupExtension.php
@@ -7,10 +7,10 @@ use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\PriceGroup\Event\PriceGroupBasicLoadedEvent;
 use Shopware\PriceGroup\Event\PriceGroupDetailLoadedEvent;
 use Shopware\PriceGroup\Event\PriceGroupWrittenEvent;
-use Shopware\PriceGroup\Struct\PriceGroupBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\PriceGroup\Struct\PriceGroupBasicStruct;
 
 abstract class PriceGroupExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class PriceGroupExtension implements ExtensionInterface, EventSubscribe
         return [
             PriceGroupBasicLoadedEvent::NAME => 'priceGroupBasicLoaded',
             PriceGroupDetailLoadedEvent::NAME => 'priceGroupDetailLoaded',
-            PriceGroupWrittenEvent::NAME => 'priceGroupWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class PriceGroupExtension implements ExtensionInterface, EventSubscribe
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class PriceGroupExtension implements ExtensionInterface, EventSubscribe
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function priceGroupBasicLoaded(PriceGroupBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function priceGroupDetailLoaded(PriceGroupDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function priceGroupWritten(PriceGroupWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/PriceGroupDiscount/Controller/PriceGroupDiscountController.php
+++ b/src/PriceGroupDiscount/Controller/PriceGroupDiscountController.php
@@ -190,7 +190,7 @@ class PriceGroupDiscountController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $priceGroupDiscounts = $this->priceGroupDiscountRepository->readDetail(
+        $priceGroupDiscounts = $this->priceGroupDiscountRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/PriceGroupDiscount/Extension/PriceGroupDiscountExtension.php
+++ b/src/PriceGroupDiscount/Extension/PriceGroupDiscountExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\PriceGroupDiscount\Event\PriceGroupDiscountBasicLoadedEvent;
 use Shopware\PriceGroupDiscount\Event\PriceGroupDiscountWrittenEvent;
-use Shopware\PriceGroupDiscount\Struct\PriceGroupDiscountBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\PriceGroupDiscount\Struct\PriceGroupDiscountBasicStruct;
 
 abstract class PriceGroupDiscountExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class PriceGroupDiscountExtension implements ExtensionInterface, EventS
     {
         return [
             PriceGroupDiscountBasicLoadedEvent::NAME => 'priceGroupDiscountBasicLoaded',
-            PriceGroupDiscountWrittenEvent::NAME => 'priceGroupDiscountWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class PriceGroupDiscountExtension implements ExtensionInterface, EventS
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class PriceGroupDiscountExtension implements ExtensionInterface, EventS
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function priceGroupDiscountBasicLoaded(PriceGroupDiscountBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function priceGroupDiscountWritten(PriceGroupDiscountWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Product/Extension/ProductExtension.php
+++ b/src/Product/Extension/ProductExtension.php
@@ -7,10 +7,10 @@ use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\Product\Event\ProductBasicLoadedEvent;
 use Shopware\Product\Event\ProductDetailLoadedEvent;
 use Shopware\Product\Event\ProductWrittenEvent;
-use Shopware\Product\Struct\ProductBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Product\Struct\ProductBasicStruct;
 
 abstract class ProductExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class ProductExtension implements ExtensionInterface, EventSubscriberIn
         return [
             ProductBasicLoadedEvent::NAME => 'productBasicLoaded',
             ProductDetailLoadedEvent::NAME => 'productDetailLoaded',
-            ProductWrittenEvent::NAME => 'productWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class ProductExtension implements ExtensionInterface, EventSubscriberIn
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class ProductExtension implements ExtensionInterface, EventSubscriberIn
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productBasicLoaded(ProductBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function productDetailLoaded(ProductDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productWritten(ProductWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/ProductDetail/Controller/ProductDetailController.php
+++ b/src/ProductDetail/Controller/ProductDetailController.php
@@ -190,7 +190,7 @@ class ProductDetailController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $productDetails = $this->productDetailRepository->readDetail(
+        $productDetails = $this->productDetailRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ProductDetail/Extension/ProductDetailExtension.php
+++ b/src/ProductDetail/Extension/ProductDetailExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductDetail\Event\ProductDetailBasicLoadedEvent;
 use Shopware\ProductDetail\Event\ProductDetailWrittenEvent;
-use Shopware\ProductDetail\Struct\ProductDetailBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductDetail\Struct\ProductDetailBasicStruct;
 
 abstract class ProductDetailExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ProductDetailExtension implements ExtensionInterface, EventSubscr
     {
         return [
             ProductDetailBasicLoadedEvent::NAME => 'productDetailBasicLoaded',
-            ProductDetailWrittenEvent::NAME => 'productDetailWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ProductDetailExtension implements ExtensionInterface, EventSubscr
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ProductDetailExtension implements ExtensionInterface, EventSubscr
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productDetailBasicLoaded(ProductDetailBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productDetailWritten(ProductDetailWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ProductDetailPrice/Controller/ProductDetailPriceController.php
+++ b/src/ProductDetailPrice/Controller/ProductDetailPriceController.php
@@ -190,7 +190,7 @@ class ProductDetailPriceController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $productDetailPrices = $this->productDetailPriceRepository->readDetail(
+        $productDetailPrices = $this->productDetailPriceRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ProductDetailPrice/Extension/ProductDetailPriceExtension.php
+++ b/src/ProductDetailPrice/Extension/ProductDetailPriceExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductDetailPrice\Event\ProductDetailPriceBasicLoadedEvent;
 use Shopware\ProductDetailPrice\Event\ProductDetailPriceWrittenEvent;
-use Shopware\ProductDetailPrice\Struct\ProductDetailPriceBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductDetailPrice\Struct\ProductDetailPriceBasicStruct;
 
 abstract class ProductDetailPriceExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ProductDetailPriceExtension implements ExtensionInterface, EventS
     {
         return [
             ProductDetailPriceBasicLoadedEvent::NAME => 'productDetailPriceBasicLoaded',
-            ProductDetailPriceWrittenEvent::NAME => 'productDetailPriceWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ProductDetailPriceExtension implements ExtensionInterface, EventS
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ProductDetailPriceExtension implements ExtensionInterface, EventS
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productDetailPriceBasicLoaded(ProductDetailPriceBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productDetailPriceWritten(ProductDetailPriceWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ProductListingPrice/Extension/ProductListingPriceExtension.php
+++ b/src/ProductListingPrice/Extension/ProductListingPriceExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductListingPrice\Event\ProductListingPriceBasicLoadedEvent;
 use Shopware\ProductListingPrice\Event\ProductListingPriceWrittenEvent;
-use Shopware\ProductListingPrice\Struct\ProductListingPriceBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductListingPrice\Struct\ProductListingPriceBasicStruct;
 
 abstract class ProductListingPriceExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -26,6 +26,7 @@ abstract class ProductListingPriceExtension implements ExtensionInterface, Event
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,12 @@ abstract class ProductListingPriceExtension implements ExtensionInterface, Event
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productListingPriceBasicLoaded(ProductListingPriceBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function productListingPriceWritten(ProductListingPriceWrittenEvent $event): void
-    {
-    }
+{ }
 }

--- a/src/ProductManufacturer/Controller/ProductManufacturerController.php
+++ b/src/ProductManufacturer/Controller/ProductManufacturerController.php
@@ -190,7 +190,7 @@ class ProductManufacturerController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $productManufacturers = $this->productManufacturerRepository->readDetail(
+        $productManufacturers = $this->productManufacturerRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ProductManufacturer/Extension/ProductManufacturerExtension.php
+++ b/src/ProductManufacturer/Extension/ProductManufacturerExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductManufacturer\Event\ProductManufacturerBasicLoadedEvent;
 use Shopware\ProductManufacturer\Event\ProductManufacturerWrittenEvent;
-use Shopware\ProductManufacturer\Struct\ProductManufacturerBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductManufacturer\Struct\ProductManufacturerBasicStruct;
 
 abstract class ProductManufacturerExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ProductManufacturerExtension implements ExtensionInterface, Event
     {
         return [
             ProductManufacturerBasicLoadedEvent::NAME => 'productManufacturerBasicLoaded',
-            ProductManufacturerWrittenEvent::NAME => 'productManufacturerWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ProductManufacturerExtension implements ExtensionInterface, Event
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ProductManufacturerExtension implements ExtensionInterface, Event
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productManufacturerBasicLoaded(ProductManufacturerBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productManufacturerWritten(ProductManufacturerWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ProductMedia/Controller/ProductMediaController.php
+++ b/src/ProductMedia/Controller/ProductMediaController.php
@@ -190,7 +190,7 @@ class ProductMediaController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $productMedias = $this->productMediaRepository->readDetail(
+        $productMedias = $this->productMediaRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ProductMedia/Extension/ProductMediaExtension.php
+++ b/src/ProductMedia/Extension/ProductMediaExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductMedia\Event\ProductMediaBasicLoadedEvent;
 use Shopware\ProductMedia\Event\ProductMediaWrittenEvent;
-use Shopware\ProductMedia\Struct\ProductMediaBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductMedia\Struct\ProductMediaBasicStruct;
 
 abstract class ProductMediaExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ProductMediaExtension implements ExtensionInterface, EventSubscri
     {
         return [
             ProductMediaBasicLoadedEvent::NAME => 'productMediaBasicLoaded',
-            ProductMediaWrittenEvent::NAME => 'productMediaWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ProductMediaExtension implements ExtensionInterface, EventSubscri
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ProductMediaExtension implements ExtensionInterface, EventSubscri
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productMediaBasicLoaded(ProductMediaBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productMediaWritten(ProductMediaWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ProductStream/Controller/ProductStreamController.php
+++ b/src/ProductStream/Controller/ProductStreamController.php
@@ -190,7 +190,7 @@ class ProductStreamController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $productStreams = $this->productStreamRepository->readDetail(
+        $productStreams = $this->productStreamRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ProductStream/Extension/ProductStreamExtension.php
+++ b/src/ProductStream/Extension/ProductStreamExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductStream\Event\ProductStreamBasicLoadedEvent;
 use Shopware\ProductStream\Event\ProductStreamWrittenEvent;
-use Shopware\ProductStream\Struct\ProductStreamBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductStream\Struct\ProductStreamBasicStruct;
 
 abstract class ProductStreamExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ProductStreamExtension implements ExtensionInterface, EventSubscr
     {
         return [
             ProductStreamBasicLoadedEvent::NAME => 'productStreamBasicLoaded',
-            ProductStreamWrittenEvent::NAME => 'productStreamWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ProductStreamExtension implements ExtensionInterface, EventSubscr
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ProductStreamExtension implements ExtensionInterface, EventSubscr
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productStreamBasicLoaded(ProductStreamBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productStreamWritten(ProductStreamWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ProductVote/Controller/ProductVoteController.php
+++ b/src/ProductVote/Controller/ProductVoteController.php
@@ -190,7 +190,7 @@ class ProductVoteController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $productVotes = $this->productVoteRepository->readDetail(
+        $productVotes = $this->productVoteRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ProductVote/Extension/ProductVoteExtension.php
+++ b/src/ProductVote/Extension/ProductVoteExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductVote\Event\ProductVoteBasicLoadedEvent;
 use Shopware\ProductVote\Event\ProductVoteWrittenEvent;
-use Shopware\ProductVote\Struct\ProductVoteBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductVote\Struct\ProductVoteBasicStruct;
 
 abstract class ProductVoteExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ProductVoteExtension implements ExtensionInterface, EventSubscrib
     {
         return [
             ProductVoteBasicLoadedEvent::NAME => 'productVoteBasicLoaded',
-            ProductVoteWrittenEvent::NAME => 'productVoteWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ProductVoteExtension implements ExtensionInterface, EventSubscrib
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ProductVoteExtension implements ExtensionInterface, EventSubscrib
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productVoteBasicLoaded(ProductVoteBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function productVoteWritten(ProductVoteWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ProductVoteAverage/Extension/ProductVoteAverageExtension.php
+++ b/src/ProductVoteAverage/Extension/ProductVoteAverageExtension.php
@@ -6,10 +6,10 @@ use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
 use Shopware\ProductVoteAverage\Event\ProductVoteAverageBasicLoadedEvent;
 use Shopware\ProductVoteAverage\Event\ProductVoteAverageWrittenEvent;
-use Shopware\ProductVoteAverage\Struct\ProductVoteAverageBasicStruct;
 use Shopware\Search\QueryBuilder;
 use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ProductVoteAverage\Struct\ProductVoteAverageBasicStruct;
 
 abstract class ProductVoteAverageExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -26,6 +26,7 @@ abstract class ProductVoteAverageExtension implements ExtensionInterface, EventS
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,12 @@ abstract class ProductVoteAverageExtension implements ExtensionInterface, EventS
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function productVoteAverageBasicLoaded(ProductVoteAverageBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function productVoteAverageWritten(ProductVoteAverageWrittenEvent $event): void
-    {
-    }
+{ }
 }

--- a/src/SeoUrl/Command/CleanupSeoUrlsCommand.php
+++ b/src/SeoUrl/Command/CleanupSeoUrlsCommand.php
@@ -25,8 +25,8 @@
 namespace Shopware\SeoUrl\Command;
 
 use Shopware\Context\Struct\TranslationContext;
-use Shopware\Search\Condition\CanonicalCondition;
 use Shopware\Search\Criteria;
+use Shopware\Search\Query\TermQuery;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,20 +46,20 @@ class CleanupSeoUrlsCommand extends ContainerAwareCommand
         $repo = $this->getContainer()->get('shopware.seo_url.repository');
 
         $criteria = new Criteria();
-        $criteria->offset(0);
-        $criteria->limit(100);
-        $criteria->addCondition(new CanonicalCondition(false));
+        $criteria->setOffset(0);
+        $criteria->setLimit(100);
+        $criteria->addFilter(new TermQuery('is_canonical', false));
 
-        $context = new TranslationContext(1, true, null);
+        $context = new TranslationContext('SWAG-SHOP-UUID-1', true, null);
 
-        $ids = $repo->search($criteria, $context)->getIds();
+        $ids = $repo->search($criteria, $context)->getUuids();
 
         do {
             $repo->delete($ids);
 
-            $criteria->offset($criteria->getOffset() + $criteria->getLimit());
+            $criteria->setOffset($criteria->getOffset() + $criteria->getLimit());
 
-            $ids = $repo->search($criteria, $context)->getIds();
+            $ids = $repo->search($criteria, $context)->getUuids();
         } while ($ids);
     }
 }

--- a/src/SeoUrl/Controller/SeoUrlController.php
+++ b/src/SeoUrl/Controller/SeoUrlController.php
@@ -190,7 +190,7 @@ class SeoUrlController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $seoUrls = $this->seoUrlRepository->readDetail(
+        $seoUrls = $this->seoUrlRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/SeoUrl/Extension/SeoUrlExtension.php
+++ b/src/SeoUrl/Extension/SeoUrlExtension.php
@@ -4,12 +4,12 @@ namespace Shopware\SeoUrl\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\SeoUrl\Event\SeoUrlBasicLoadedEvent;
 use Shopware\SeoUrl\Event\SeoUrlWrittenEvent;
-use Shopware\SeoUrl\Struct\SeoUrlBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\SeoUrl\Struct\SeoUrlBasicStruct;
 
 abstract class SeoUrlExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class SeoUrlExtension implements ExtensionInterface, EventSubscriberInt
     {
         return [
             SeoUrlBasicLoadedEvent::NAME => 'seoUrlBasicLoaded',
-            SeoUrlWrittenEvent::NAME => 'seoUrlWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class SeoUrlExtension implements ExtensionInterface, EventSubscriberInt
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class SeoUrlExtension implements ExtensionInterface, EventSubscriberInt
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function seoUrlBasicLoaded(SeoUrlBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function seoUrlWritten(SeoUrlWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/ShippingMethod/Extension/ShippingMethodExtension.php
+++ b/src/ShippingMethod/Extension/ShippingMethodExtension.php
@@ -4,13 +4,13 @@ namespace Shopware\ShippingMethod\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\ShippingMethod\Event\ShippingMethodBasicLoadedEvent;
 use Shopware\ShippingMethod\Event\ShippingMethodDetailLoadedEvent;
 use Shopware\ShippingMethod\Event\ShippingMethodWrittenEvent;
-use Shopware\ShippingMethod\Struct\ShippingMethodBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ShippingMethod\Struct\ShippingMethodBasicStruct;
 
 abstract class ShippingMethodExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class ShippingMethodExtension implements ExtensionInterface, EventSubsc
         return [
             ShippingMethodBasicLoadedEvent::NAME => 'shippingMethodBasicLoaded',
             ShippingMethodDetailLoadedEvent::NAME => 'shippingMethodDetailLoaded',
-            ShippingMethodWrittenEvent::NAME => 'shippingMethodWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class ShippingMethodExtension implements ExtensionInterface, EventSubsc
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class ShippingMethodExtension implements ExtensionInterface, EventSubsc
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function shippingMethodBasicLoaded(ShippingMethodBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function shippingMethodDetailLoaded(ShippingMethodDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function shippingMethodWritten(ShippingMethodWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/ShippingMethodPrice/Controller/ShippingMethodPriceController.php
+++ b/src/ShippingMethodPrice/Controller/ShippingMethodPriceController.php
@@ -190,7 +190,7 @@ class ShippingMethodPriceController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $shippingMethodPrices = $this->shippingMethodPriceRepository->readDetail(
+        $shippingMethodPrices = $this->shippingMethodPriceRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ShippingMethodPrice/Extension/ShippingMethodPriceExtension.php
+++ b/src/ShippingMethodPrice/Extension/ShippingMethodPriceExtension.php
@@ -4,12 +4,12 @@ namespace Shopware\ShippingMethodPrice\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\ShippingMethodPrice\Event\ShippingMethodPriceBasicLoadedEvent;
 use Shopware\ShippingMethodPrice\Event\ShippingMethodPriceWrittenEvent;
-use Shopware\ShippingMethodPrice\Struct\ShippingMethodPriceBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ShippingMethodPrice\Struct\ShippingMethodPriceBasicStruct;
 
 abstract class ShippingMethodPriceExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ShippingMethodPriceExtension implements ExtensionInterface, Event
     {
         return [
             ShippingMethodPriceBasicLoadedEvent::NAME => 'shippingMethodPriceBasicLoaded',
-            ShippingMethodPriceWrittenEvent::NAME => 'shippingMethodPriceWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ShippingMethodPriceExtension implements ExtensionInterface, Event
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ShippingMethodPriceExtension implements ExtensionInterface, Event
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function shippingMethodPriceBasicLoaded(ShippingMethodPriceBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function shippingMethodPriceWritten(ShippingMethodPriceWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Shop/Extension/ShopExtension.php
+++ b/src/Shop/Extension/ShopExtension.php
@@ -4,13 +4,13 @@ namespace Shopware\Shop\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\Shop\Event\ShopBasicLoadedEvent;
 use Shopware\Shop\Event\ShopDetailLoadedEvent;
 use Shopware\Shop\Event\ShopWrittenEvent;
-use Shopware\Shop\Struct\ShopBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Shop\Struct\ShopBasicStruct;
 
 abstract class ShopExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -19,7 +19,7 @@ abstract class ShopExtension implements ExtensionInterface, EventSubscriberInter
         return [
             ShopBasicLoadedEvent::NAME => 'shopBasicLoaded',
             ShopDetailLoadedEvent::NAME => 'shopDetailLoaded',
-            ShopWrittenEvent::NAME => 'shopWritten',
+            
         ];
     }
 
@@ -28,6 +28,7 @@ abstract class ShopExtension implements ExtensionInterface, EventSubscriberInter
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -45,18 +46,15 @@ abstract class ShopExtension implements ExtensionInterface, EventSubscriberInter
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function shopBasicLoaded(ShopBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
     public function shopDetailLoaded(ShopDetailLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function shopWritten(ShopWrittenEvent $event): void
-    {
-    }
+    
+
 }

--- a/src/ShopTemplate/Controller/ShopTemplateController.php
+++ b/src/ShopTemplate/Controller/ShopTemplateController.php
@@ -190,7 +190,7 @@ class ShopTemplateController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $shopTemplates = $this->shopTemplateRepository->readDetail(
+        $shopTemplates = $this->shopTemplateRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/ShopTemplate/Extension/ShopTemplateExtension.php
+++ b/src/ShopTemplate/Extension/ShopTemplateExtension.php
@@ -4,12 +4,12 @@ namespace Shopware\ShopTemplate\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\ShopTemplate\Event\ShopTemplateBasicLoadedEvent;
 use Shopware\ShopTemplate\Event\ShopTemplateWrittenEvent;
-use Shopware\ShopTemplate\Struct\ShopTemplateBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\ShopTemplate\Struct\ShopTemplateBasicStruct;
 
 abstract class ShopTemplateExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class ShopTemplateExtension implements ExtensionInterface, EventSubscri
     {
         return [
             ShopTemplateBasicLoadedEvent::NAME => 'shopTemplateBasicLoaded',
-            ShopTemplateWrittenEvent::NAME => 'shopTemplateWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class ShopTemplateExtension implements ExtensionInterface, EventSubscri
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class ShopTemplateExtension implements ExtensionInterface, EventSubscri
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function shopTemplateBasicLoaded(ShopTemplateBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function shopTemplateWritten(ShopTemplateWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Storefront/Controller/CartController.php
+++ b/src/Storefront/Controller/CartController.php
@@ -55,7 +55,7 @@ class CartController extends Controller
         }
         $cartService = $this->get('shopware.cart.storefront_service');
         $cartService->add(
-            new LineItem($identifier, ProductProcessor::TYPE_PRODUCT, (int) $quantity)
+            new LineItem($identifier, ProductProcessor::TYPE_PRODUCT, $quantity)
         );
 
         return $this->conditionalResponse($request, $target);

--- a/src/Storefront/Page/Detail/DetailPageLoader.php
+++ b/src/Storefront/Page/Detail/DetailPageLoader.php
@@ -22,6 +22,6 @@ class DetailPageLoader
     {
         $collection = $this->productRepository->read([$productUuid], $context);
 
-        return $collection->get($productUuid);
+        return ProductBasicStruct::createFrom($collection->get($productUuid));
     }
 }

--- a/src/Tax/Controller/TaxController.php
+++ b/src/Tax/Controller/TaxController.php
@@ -190,7 +190,7 @@ class TaxController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $taxes = $this->taxRepository->readDetail(
+        $taxes = $this->taxRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/Tax/Extension/TaxExtension.php
+++ b/src/Tax/Extension/TaxExtension.php
@@ -4,12 +4,12 @@ namespace Shopware\Tax\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\Tax\Event\TaxBasicLoadedEvent;
 use Shopware\Tax\Event\TaxWrittenEvent;
-use Shopware\Tax\Struct\TaxBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Tax\Struct\TaxBasicStruct;
 
 abstract class TaxExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class TaxExtension implements ExtensionInterface, EventSubscriberInterf
     {
         return [
             TaxBasicLoadedEvent::NAME => 'taxBasicLoaded',
-            TaxWrittenEvent::NAME => 'taxWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class TaxExtension implements ExtensionInterface, EventSubscriberInterf
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class TaxExtension implements ExtensionInterface, EventSubscriberInterf
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function taxBasicLoaded(TaxBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function taxWritten(TaxWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/TaxAreaRule/Controller/TaxAreaRuleController.php
+++ b/src/TaxAreaRule/Controller/TaxAreaRuleController.php
@@ -190,7 +190,7 @@ class TaxAreaRuleController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $taxAreaRules = $this->taxAreaRuleRepository->readDetail(
+        $taxAreaRules = $this->taxAreaRuleRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/TaxAreaRule/Extension/TaxAreaRuleExtension.php
+++ b/src/TaxAreaRule/Extension/TaxAreaRuleExtension.php
@@ -4,12 +4,12 @@ namespace Shopware\TaxAreaRule\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\TaxAreaRule\Event\TaxAreaRuleBasicLoadedEvent;
 use Shopware\TaxAreaRule\Event\TaxAreaRuleWrittenEvent;
-use Shopware\TaxAreaRule\Struct\TaxAreaRuleBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\TaxAreaRule\Struct\TaxAreaRuleBasicStruct;
 
 abstract class TaxAreaRuleExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class TaxAreaRuleExtension implements ExtensionInterface, EventSubscrib
     {
         return [
             TaxAreaRuleBasicLoadedEvent::NAME => 'taxAreaRuleBasicLoaded',
-            TaxAreaRuleWrittenEvent::NAME => 'taxAreaRuleWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class TaxAreaRuleExtension implements ExtensionInterface, EventSubscrib
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class TaxAreaRuleExtension implements ExtensionInterface, EventSubscrib
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function taxAreaRuleBasicLoaded(TaxAreaRuleBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function taxAreaRuleWritten(TaxAreaRuleWrittenEvent $event): void
-    {
-    }
+    
 }

--- a/src/Translation/Event/ImportAdvanceEvent.php
+++ b/src/Translation/Event/ImportAdvanceEvent.php
@@ -10,7 +10,7 @@ class ImportAdvanceEvent extends Event
     const EVENT_NAME = 'translation.import.advance';
 
     /**
-     * @var string
+     * @var SplFileInfo
      */
     private $file;
 
@@ -21,6 +21,6 @@ class ImportAdvanceEvent extends Event
 
     public function getFile(): string
     {
-        return $this->file;
+        return (string) $this->file;
     }
 }

--- a/src/Unit/Controller/UnitController.php
+++ b/src/Unit/Controller/UnitController.php
@@ -190,7 +190,7 @@ class UnitController extends ApiController
             return $this->createResponse(['errors' => $error], $context, 400);
         }
 
-        $units = $this->unitRepository->readDetail(
+        $units = $this->unitRepository->read(
             [$payload['uuid']],
             $context->getShopContext()->getTranslationContext()
         );

--- a/src/Unit/Extension/UnitExtension.php
+++ b/src/Unit/Extension/UnitExtension.php
@@ -4,12 +4,12 @@ namespace Shopware\Unit\Extension;
 
 use Shopware\Context\Struct\TranslationContext;
 use Shopware\Framework\Factory\ExtensionInterface;
-use Shopware\Search\QueryBuilder;
-use Shopware\Search\QuerySelection;
 use Shopware\Unit\Event\UnitBasicLoadedEvent;
 use Shopware\Unit\Event\UnitWrittenEvent;
-use Shopware\Unit\Struct\UnitBasicStruct;
+use Shopware\Search\QueryBuilder;
+use Shopware\Search\QuerySelection;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Shopware\Unit\Struct\UnitBasicStruct;
 
 abstract class UnitExtension implements ExtensionInterface, EventSubscriberInterface
 {
@@ -17,7 +17,7 @@ abstract class UnitExtension implements ExtensionInterface, EventSubscriberInter
     {
         return [
             UnitBasicLoadedEvent::NAME => 'unitBasicLoaded',
-            UnitWrittenEvent::NAME => 'unitWritten',
+            
         ];
     }
 
@@ -26,6 +26,7 @@ abstract class UnitExtension implements ExtensionInterface, EventSubscriberInter
         QueryBuilder $query,
         TranslationContext $context
     ): void {
+
     }
 
     public function getDetailFields(): array
@@ -43,14 +44,11 @@ abstract class UnitExtension implements ExtensionInterface, EventSubscriberInter
         array $data,
         QuerySelection $selection,
         TranslationContext $translation
-    ): void {
-    }
+    ): void
+    { }
 
     public function unitBasicLoaded(UnitBasicLoadedEvent $event): void
-    {
-    }
+    { }
 
-    public function unitWritten(UnitWrittenEvent $event): void
-    {
-    }
+    
 }


### PR DESCRIPTION
The Docker Team says themselves:
> Eliminate the “it works on my machine” problem once and for all.

That's not true for the shopware docker containers unfortunately.

### 1. Why is this change necessary?
My local user is in a group with ID 20. Shopware uses this ID for the group inside the docker container, too. The problem:

> Many Linux systems reserve the GID number range 0 to 99 for statically allocated groups[...]

from https://en.wikipedia.org/wiki/Group_identifier#Reserved_ranges

This means:
![docker](https://user-images.githubusercontent.com/1859343/31467344-ef21fcd0-aed9-11e7-9e5d-e0e0ea33e23d.png)

Now I can't build the container. We should rely on static variables inside our container so we are independent of the host system.

### 2. What does this change do, exactly?
The userID and groupID of the container's user won't be determinated by the host user's ids.

### 3. Describe each step to reproduce the issue or behaviour.
Use a unix system with a user's group's id is 20. Try to install the docker image. It fails.

### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?
none

### 6. Checklist

- [X] I have written tests and verified that they fail without my change
- [X] I have squashed any insignificant commits
- [X] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.